### PR TITLE
Add upload URL generation

### DIFF
--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -95,6 +95,7 @@ func SetupRouter(storageFactory oss.StorageFactory, md5Calculator *function.MD5C
 		authorized.GET("/oss/files", ossFileHandler.List)
 		authorized.DELETE("/oss/files/:id", ossFileHandler.Delete)
 		authorized.GET("/oss/files/:id/download", ossFileHandler.GetDownloadURL)
+		authorized.POST("/oss/upload-url", ossFileHandler.GenerateUploadURL)
 		//authorized.GET("/oss/files/by-filename", ossFileHandler.GetByOriginalFilename)
 
 		// 分片上传

--- a/internal/oss/aliyun.go
+++ b/internal/oss/aliyun.go
@@ -399,3 +399,24 @@ func (s *AliyunOSSService) GenerateDownloadURLWithBucket(objectKey string, downl
 	}
 	return signedURL, expires, nil
 }
+
+// GenerateUploadURL 生成PUT上传URL
+func (s *AliyunOSSService) GenerateUploadURL(objectKey, regionCode, bucketName string) (string, error) {
+	endpoint := fmt.Sprintf("https://oss-%s.aliyuncs.com", regionCode)
+	client, err := oss.New(endpoint, s.config.AccessKeyID, s.config.AccessKeySecret)
+	if err != nil {
+		return "", fmt.Errorf("创建OSS客户端失败: %w", err)
+	}
+
+	bucket, err := client.Bucket(bucketName)
+	if err != nil {
+		return "", fmt.Errorf("获取存储桶失败: %w", err)
+	}
+
+	signedURL, err := bucket.SignURL(objectKey, oss.HTTPPut, int64(s.config.GetOSSURLExpiration().Seconds()))
+	if err != nil {
+		return "", fmt.Errorf("生成上传URL失败: %w", err)
+	}
+
+	return signedURL, nil
+}

--- a/internal/oss/cloudflare.go
+++ b/internal/oss/cloudflare.go
@@ -225,6 +225,47 @@ func (s *CloudflareR2Service) GenerateDownloadURL(objectKey string, expiration t
 	return presignResult.URL, expires, nil
 }
 
+// GenerateUploadURL 生成PUT上传URL
+func (s *CloudflareR2Service) GenerateUploadURL(objectKey, regionCode, bucketName string) (string, error) {
+	creds := credentials.NewStaticCredentialsProvider(s.config.AccessKeyID, s.config.SecretAccessKey, "")
+	endpoint := fmt.Sprintf("https://%s.r2.cloudflarestorage.com", s.config.AccountID)
+
+	awsCfg, err := awsconfig.LoadDefaultConfig(
+		context.TODO(),
+		awsconfig.WithRegion("auto"),
+		awsconfig.WithCredentialsProvider(creds),
+		awsconfig.WithEndpointResolverWithOptions(
+			aws.EndpointResolverWithOptionsFunc(
+				func(service, region string, options ...interface{}) (aws.Endpoint, error) {
+					return aws.Endpoint{
+						URL:               endpoint,
+						SigningRegion:     "auto",
+						HostnameImmutable: true,
+					}, nil
+				},
+			),
+		),
+	)
+	if err != nil {
+		return "", fmt.Errorf("创建R2配置失败: %w", err)
+	}
+
+	client := s3.NewFromConfig(awsCfg)
+	presignClient := s3.NewPresignClient(client)
+
+	presignResult, err := presignClient.PresignPutObject(context.Background(), &s3.PutObjectInput{
+		Bucket: aws.String(bucketName),
+		Key:    aws.String(objectKey),
+	}, func(opts *s3.PresignOptions) {
+		opts.Expires = s.config.GetOSSURLExpiration()
+	})
+	if err != nil {
+		return "", fmt.Errorf("生成CloudFlare R2上传URL失败: %w", err)
+	}
+
+	return presignResult.URL, nil
+}
+
 // DeleteObject 删除对象
 func (s *CloudflareR2Service) DeleteObject(objectKey string) error {
 	fullObjectKey := s.getObjectKey(objectKey)

--- a/internal/oss/interface.go
+++ b/internal/oss/interface.go
@@ -47,6 +47,12 @@ type StorageService interface {
 	// CompleteMultipartUploadToBucket 完成分片上传到指定的存储桶
 	CompleteMultipartUploadToBucket(objectKey string, uploadID string, parts []Part, regionCode string, bucketName string) (string, error)
 
+	// GenerateUploadURL 生成上传URL
+	// objectKey: 对象键
+	// regionCode: 区域代码
+	// bucketName: 存储桶名称
+	GenerateUploadURL(objectKey, regionCode, bucketName string) (string, error)
+
 	// AbortMultipartUpload 取消分片上传
 	AbortMultipartUpload(objectKey string, uploadID string) error
 


### PR DESCRIPTION
## Summary
- extend StorageService interface with `GenerateUploadURL`
- support upload URL generation for Aliyun OSS, AWS S3 and Cloudflare R2
- expose POST `/oss/upload-url` route
- implement handler to create object key and return pre-signed upload URL

## Testing
- `go build -o /tmp/app ./cmd`


------
https://chatgpt.com/codex/tasks/task_e_6850c3315dec832aa481fc7b9e5990d9