### PR TITLE
Add upload progress SSE

### DIFF
--- a/internal/api/handlers/oss_file.go
+++ b/internal/api/handlers/oss_file.go
@@ -5,11 +5,13 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/myysophia/ossmanager-backend/internal/auth"
 
 	"github.com/gin-gonic/gin"
 	"github.com/myysophia/ossmanager-backend/internal/db/models"
 	"github.com/myysophia/ossmanager-backend/internal/oss"
+	"github.com/myysophia/ossmanager-backend/internal/upload"
 	"github.com/myysophia/ossmanager-backend/internal/utils"
 	"gorm.io/gorm"
 )
@@ -73,7 +75,10 @@ func (h *OSSFileHandler) Upload(c *gin.Context) {
 	username, _ := c.Get("username")
 	objectKey := utils.GenerateObjectKey(username.(string), ext)
 
-	// 上传文件
+	// 生成上传任务ID并记录总大小
+	taskID := uuid.NewString()
+	upload.DefaultManager.Start(taskID, file.Size)
+
 	src, err := file.Open()
 	if err != nil {
 		h.Error(c, utils.CodeServerError, "打开文件失败")
@@ -81,12 +86,20 @@ func (h *OSSFileHandler) Upload(c *gin.Context) {
 	}
 	defer src.Close()
 
-	// 使用用户指定的 bucket 上传
-	uploadURL, err := storage.UploadToBucket(src, objectKey, regionCode, bucketName)
+	// 使用用户指定的 bucket 上传并监听进度
+	uploadURL, err := storage.UploadToBucketWithProgress(src, objectKey, regionCode, bucketName, func(consumed, total int64) {
+		if total == 0 {
+			total = file.Size
+		}
+		upload.DefaultManager.Update(taskID, consumed)
+	})
 	if err != nil {
 		h.Error(c, utils.CodeServerError, "上传文件失败")
+		upload.DefaultManager.Finish(taskID)
 		return
 	}
+
+	upload.DefaultManager.Finish(taskID)
 
 	// 从配置中获取过期时间，如果未配置则默认为24小时
 	expireTime := config.URLExpireTime

--- a/internal/api/handlers/upload_progress.go
+++ b/internal/api/handlers/upload_progress.go
@@ -1,0 +1,53 @@
+package handlers
+
+import (
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+	"github.com/myysophia/ossmanager-backend/internal/upload"
+)
+
+// UploadProgressHandler 处理上传进度查询和SSE
+type UploadProgressHandler struct {
+	*BaseHandler
+}
+
+func NewUploadProgressHandler() *UploadProgressHandler {
+	return &UploadProgressHandler{BaseHandler: NewBaseHandler()}
+}
+
+// GetProgress 返回上传进度
+func (h *UploadProgressHandler) GetProgress(c *gin.Context) {
+	id := c.Param("id")
+	if p, ok := upload.DefaultManager.Get(id); ok {
+		h.Success(c, p)
+	} else {
+		c.JSON(http.StatusNotFound, gin.H{"message": "task not found"})
+	}
+}
+
+// StreamProgress 使用SSE实时推送进度
+func (h *UploadProgressHandler) StreamProgress(c *gin.Context) {
+	id := c.Param("id")
+	c.Writer.Header().Set("Content-Type", "text/event-stream")
+	c.Writer.Header().Set("Cache-Control", "no-cache")
+	c.Writer.Header().Set("Connection", "keep-alive")
+	c.Writer.Flush()
+
+	ch := upload.DefaultManager.Subscribe(id)
+	defer upload.DefaultManager.Unsubscribe(id, ch)
+
+	notify := c.Writer.CloseNotify()
+	for {
+		select {
+		case p, ok := <-ch:
+			if !ok {
+				return
+			}
+			c.SSEvent("progress", p)
+			c.Writer.Flush()
+		case <-notify:
+			return
+		}
+	}
+}

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -32,6 +32,7 @@ func SetupRouter(storageFactory oss.StorageFactory, md5Calculator *function.MD5C
 	roleHandler := handlers.NewRoleHandler(db)                 // 角色管理处理器
 	permissionHandler := handlers.NewPermissionHandler(db)     // 权限管理处理器
 	regionBucketHandler := handlers.NewRegionBucketHandler(db) // 区域存储桶处理器
+	uploadProgressHandler := handlers.NewUploadProgressHandler()
 
 	// 公开路由
 	public := router.Group("/api/v1")
@@ -146,6 +147,12 @@ func SetupRouter(storageFactory oss.StorageFactory, md5Calculator *function.MD5C
 			roleBucketAccess.GET("/:id", roleHandler.GetRoleBucketAccess)
 			roleBucketAccess.PUT("/:id", roleHandler.UpdateRoleBucketAccess)
 			roleBucketAccess.DELETE("/:id", roleHandler.DeleteRoleBucketAccess)
+		}
+
+		uploads := authorized.Group("/uploads")
+		{
+			uploads.GET("/:id/progress", uploadProgressHandler.GetProgress)
+			uploads.GET("/:id/stream", uploadProgressHandler.StreamProgress)
 		}
 	}
 

--- a/internal/oss/aws.go
+++ b/internal/oss/aws.go
@@ -3,6 +3,10 @@ package oss
 import (
 	"context"
 	"fmt"
+	"io"
+	"path"
+	"time"
+
 	"github.com/aws/aws-sdk-go-v2/aws"
 	awsconfig "github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/credentials"
@@ -11,9 +15,6 @@ import (
 	"github.com/myysophia/ossmanager-backend/internal/config"
 	"github.com/myysophia/ossmanager-backend/internal/logger"
 	"go.uber.org/zap"
-	"io"
-	"path"
-	"time"
 )
 
 // AWSS3Service AWS S3存储服务
@@ -99,6 +100,12 @@ func (s *AWSS3Service) Upload(file io.Reader, objectKey string) (string, error) 
 	}
 
 	return presignResult.URL, nil
+}
+
+// UploadToBucketWithProgress 上传文件到指定的存储桶并回调上传进度
+func (s *AWSS3Service) UploadToBucketWithProgress(file io.Reader, objectKey string, regionCode string, bucketName string, progressCallback func(consumedBytes, totalBytes int64)) (string, error) {
+	// AWS S3 默认使用配置中的桶，暂不支持回调进度，直接调用 Upload
+	return s.Upload(file, objectKey)
 }
 
 // InitMultipartUpload 初始化分片上传

--- a/internal/oss/cloudflare.go
+++ b/internal/oss/cloudflare.go
@@ -3,6 +3,10 @@ package oss
 import (
 	"context"
 	"fmt"
+	"io"
+	"path"
+	"time"
+
 	"github.com/aws/aws-sdk-go-v2/aws"
 	awsconfig "github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/credentials"
@@ -11,9 +15,6 @@ import (
 	"github.com/myysophia/ossmanager-backend/internal/config"
 	"github.com/myysophia/ossmanager-backend/internal/logger"
 	"go.uber.org/zap"
-	"io"
-	"path"
-	"time"
 )
 
 // CloudflareR2Service Cloudflare R2存储服务
@@ -113,6 +114,12 @@ func (s *CloudflareR2Service) Upload(file io.Reader, objectKey string) (string, 
 	}
 
 	return presignResult.URL, nil
+}
+
+// UploadToBucketWithProgress 上传文件到指定的存储桶并回调上传进度
+func (s *CloudflareR2Service) UploadToBucketWithProgress(file io.Reader, objectKey string, regionCode string, bucketName string, progressCallback func(consumedBytes, totalBytes int64)) (string, error) {
+	// R2 同样暂未实现进度回调，直接调用 Upload
+	return s.Upload(file, objectKey)
 }
 
 // InitMultipartUpload 初始化分片上传

--- a/internal/oss/interface.go
+++ b/internal/oss/interface.go
@@ -35,6 +35,10 @@ type StorageService interface {
 	// UploadToBucket 上传文件到指定的存储桶
 	UploadToBucket(file io.Reader, objectKey string, regionCode string, bucketName string) (string, error)
 
+	// UploadToBucketWithProgress 上传文件到指定的存储桶并回调上传进度
+	// progressCallback: 回调函数，参数为已上传字节数和总字节数
+	UploadToBucketWithProgress(file io.Reader, objectKey string, regionCode string, bucketName string, progressCallback func(consumedBytes, totalBytes int64)) (string, error)
+
 	// InitMultipartUpload 初始化分片上传
 	InitMultipartUpload(objectKey string) (string, []string, error)
 

--- a/internal/oss/tests/aliyun_test.go
+++ b/internal/oss/tests/aliyun_test.go
@@ -1,0 +1,1 @@
+package oss

--- a/internal/oss/tests/aws_test.go
+++ b/internal/oss/tests/aws_test.go
@@ -1,0 +1,1 @@
+package oss

--- a/internal/oss/tests/factory_test.go
+++ b/internal/oss/tests/factory_test.go
@@ -1,0 +1,1 @@
+package oss

--- a/internal/upload/manager.go
+++ b/internal/upload/manager.go
@@ -1,0 +1,95 @@
+package upload
+
+import "sync"
+
+type Progress struct {
+	Total    int64 `json:"total"`
+	Uploaded int64 `json:"uploaded"`
+}
+
+type Manager struct {
+	mu          sync.RWMutex
+	progresses  map[string]*Progress
+	subscribers map[string]map[chan Progress]struct{}
+}
+
+func NewManager() *Manager {
+	return &Manager{
+		progresses:  make(map[string]*Progress),
+		subscribers: make(map[string]map[chan Progress]struct{}),
+	}
+}
+
+var DefaultManager = NewManager()
+
+func (m *Manager) Start(id string, total int64) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.progresses[id] = &Progress{Total: total}
+}
+
+func (m *Manager) Update(id string, uploaded int64) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if p, ok := m.progresses[id]; ok {
+		if uploaded > p.Uploaded {
+			p.Uploaded = uploaded
+		}
+		for ch := range m.subscribers[id] {
+			select {
+			case ch <- *p:
+			default:
+			}
+		}
+	}
+}
+
+func (m *Manager) Finish(id string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	delete(m.progresses, id)
+	if subs, ok := m.subscribers[id]; ok {
+		for ch := range subs {
+			close(ch)
+		}
+		delete(m.subscribers, id)
+	}
+}
+
+func (m *Manager) Get(id string) (Progress, bool) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	p, ok := m.progresses[id]
+	if !ok {
+		return Progress{}, false
+	}
+	return *p, true
+}
+
+func (m *Manager) Subscribe(id string) chan Progress {
+	ch := make(chan Progress, 10)
+	m.mu.Lock()
+	if _, ok := m.subscribers[id]; !ok {
+		m.subscribers[id] = make(map[chan Progress]struct{})
+	}
+	m.subscribers[id][ch] = struct{}{}
+	if p, ok := m.progresses[id]; ok {
+		ch <- *p
+	}
+	m.mu.Unlock()
+	return ch
+}
+
+func (m *Manager) Unsubscribe(id string, ch chan Progress) {
+	m.mu.Lock()
+	if subs, ok := m.subscribers[id]; ok {
+		if _, ok := subs[ch]; ok {
+			delete(subs, ch)
+			close(ch)
+		}
+		if len(subs) == 0 {
+			delete(m.subscribers, id)
+		}
+	}
+	m.mu.Unlock()
+}

--- a/internal/upload/reader.go
+++ b/internal/upload/reader.go
@@ -1,0 +1,35 @@
+package upload
+
+import "io"
+
+// Reader wraps an io.Reader and reports progress to Manager.
+type Reader struct {
+	r        io.Reader
+	id       string
+	read     int64
+	callback func(int64)
+}
+
+func NewReader(id string, r io.Reader) *Reader {
+	return &Reader{r: r, id: id}
+}
+
+func NewReaderWithCallback(id string, r io.Reader, cb func(int64)) *Reader {
+	return &Reader{r: r, id: id, callback: cb}
+}
+
+func (pr *Reader) Read(p []byte) (int, error) {
+	n, err := pr.r.Read(p)
+	if n > 0 {
+		pr.read += int64(n)
+		DefaultManager.Update(pr.id, pr.read)
+		if pr.callback != nil {
+			pr.callback(pr.read)
+		}
+	}
+	return n, err
+}
+
+func (pr *Reader) BytesRead() int64 {
+	return pr.read
+}


### PR DESCRIPTION
## Summary
- add progress manager to store upload status and SSE subscribers
- support uploading with progress callback for Aliyun OSS
- add upload progress endpoints and wire into router
- track progress in upload handler
- stub progress method for AWS and Cloudflare

## Testing
- `go build ./...`
- `go test ./...` *(fails: imported and not used errors)*

------
https://chatgpt.com/codex/tasks/task_e_6858eb3c85b0832aa5aea28b73496e0a